### PR TITLE
feat(salvo)!: support `salvo 0.75`

### DIFF
--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -37,4 +37,4 @@ rocket = { version = "0.5.0", features = ["json"] }
 rocket-grants = { path = "../rocket-grants" }
 serde = { version = "1.0", features = ["derive"] }
 protect-salvo = { path = "../protect-salvo" }
-salvo = { version = "0.74.2" }
+salvo = { version = "0.75" }

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -37,4 +37,4 @@ rocket = { version = "0.5.0", features = ["json"] }
 rocket-grants = { path = "../rocket-grants" }
 serde = { version = "1.0", features = ["derive"] }
 protect-salvo = { path = "../protect-salvo" }
-salvo = { version = "0.70.0" }
+salvo = { version = "0.74.2" }

--- a/protect-axum/Cargo.toml
+++ b/protect-axum/Cargo.toml
@@ -23,7 +23,7 @@ macro-check = ["protect-endpoints-proc-macro"]
 axum = { version = "0.7.5", default-features = false }
 protect-endpoints-core = { workspace = true, features = ["tower"] }
 protect-endpoints-proc-macro = { workspace = true, features = ["axum"], optional = true }
-tower = { version = "0.4.13", default-features = false }
+tower = { version = "0.5", default-features = false }
 
 [dev-dependencies]
 axum = { version = "0.7.2" }

--- a/protect-salvo/Cargo.toml
+++ b/protect-salvo/Cargo.toml
@@ -20,7 +20,7 @@ default = ["macro-check"]
 macro-check = ["protect-endpoints-proc-macro"]
 
 [dependencies]
-salvo = { version = "0.70.0", default-features = false, features = ["tower-compat"] }
+salvo = { version = "0.74.2", default-features = false, features = ["tower-compat"] }
 protect-endpoints-core = { workspace = true, features = ["tower"] }
 protect-endpoints-proc-macro = { workspace = true, features = ["salvo"], optional = true }
 tower = { version = "0.4.13", default-features = false }
@@ -30,7 +30,7 @@ chrono = "0.4.35"
 http-body-util = "0.1.0"
 jsonwebtoken = "9.1.0"
 parse-display = "0.10.0"
-salvo = { version = "0.70.0", default-features = false, features = ["test"] }
+salvo = { version = "0.74.2", default-features = false, features = ["test"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 tokio = { version = "1.34.0", features = ["rt-multi-thread"] }

--- a/protect-salvo/Cargo.toml
+++ b/protect-salvo/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 description = "Authorization extension `salvo` to protect your endpoints"
 readme = "README.md"
 keywords = ["salvo", "auth", "security", "grants", "permissions"]
+rust-version = "1.80"
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
@@ -20,17 +21,18 @@ default = ["macro-check"]
 macro-check = ["protect-endpoints-proc-macro"]
 
 [dependencies]
-salvo = { version = "0.74.2", default-features = false, features = ["tower-compat"] }
+salvo = { version = "0.75.0", default-features = false }
+salvo_extra = { version = "0.75.0", default-features = false, features = ["tower-compat"] }
 protect-endpoints-core = { workspace = true, features = ["tower"] }
 protect-endpoints-proc-macro = { workspace = true, features = ["salvo"], optional = true }
-tower = { version = "0.4.13", default-features = false }
+tower = { version = "0.5", default-features = false }
 
 [dev-dependencies]
 chrono = "0.4.35"
 http-body-util = "0.1.0"
 jsonwebtoken = "9.1.0"
 parse-display = "0.10.0"
-salvo = { version = "0.74.2", default-features = false, features = ["test"] }
+salvo = { version = "0.75", default-features = false, features = ["test"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 tokio = { version = "1.34.0", features = ["rt-multi-thread"] }

--- a/protect-salvo/README.md
+++ b/protect-salvo/README.md
@@ -96,6 +96,11 @@ async fn manual_secure(details: AuthDetails) -> &'static str {
 
 You can find more [`examples`] in the git repository folder and [`documentation`].
 
+
+## Supported `actix-web` versions
+* For `protect-salvo: 0.1.*` supported version of `salvo` is `0.70.*`
+* For `protect-salvo: 0.2.*` supported version of `salvo` is `0.75.*`
+
 [`examples`]: https://github.com/DDtKey/protect-endpoints/tree/main/protect-salvo/examples
 [`documentation`]: https://docs.rs/protect-salvo
 [`salvo`]: https://github.com/salvo-rs/salvo

--- a/protect-salvo/README.md
+++ b/protect-salvo/README.md
@@ -17,9 +17,7 @@ The library can also be integrated with third-party solutions (e.g. jwt-middlewa
 
 ## How to use
 
-1. Add `tower-compat` feature to [`salvo`] dependency in your `Cargo.toml`
-
-2. Declare your
+1. Declare your
    own [authority extractor](https://docs.rs/protect-endpoints-core/latest/protect_endpoints_core/authorities/extractor/trait.AuthoritiesExtractor.html)
 
 The easiest way is to declare a function with the following signature (trait is already implemented for such Fn):
@@ -32,9 +30,12 @@ use salvo::prelude::*;
 pub async fn extract(req: &mut salvo::hyper::Request<ReqBody>) -> Result<HashSet<String>, salvo::hyper::Response<ResBody>>
 ```
 
-3. Add middleware to your application using the extractor defined in step 1
+2. Add middleware to your application using the extractor defined in step 1
 
 ```rust,ignore
+// You can use [`salvo_extra`] directly for Tower compatibility or re-exported one
+use protect_salvo::salvo_extra::TowerLayerCompat;
+
 Router::with_path("/")
     .hoop(GrantsLayer::with_extractor(extract).compat())
     .push(Router::with_path("/endpoint").get(your_handler))
@@ -42,7 +43,7 @@ Router::with_path("/")
 
 > Steps 2 and 3 can be replaced by custom middleware or integration with another libraries.
 
-4. Protect your endpoints in any convenient way from the examples below:
+3. Protect your endpoints in any convenient way from the examples below:
 
 ### Example of `proc-macro` way protection
 
@@ -95,9 +96,7 @@ async fn manual_secure(details: AuthDetails) -> &'static str {
 
 You can find more [`examples`] in the git repository folder and [`documentation`].
 
-
 [`examples`]: https://github.com/DDtKey/protect-endpoints/tree/main/protect-salvo/examples
-
 [`documentation`]: https://docs.rs/protect-salvo
-
 [`salvo`]: https://github.com/salvo-rs/salvo
+[`salvo_extra`]: https://crates.io/crates/salvo_extra

--- a/protect-salvo/src/lib.rs
+++ b/protect-salvo/src/lib.rs
@@ -10,10 +10,14 @@
 //! [`permissions`]: authorities
 //! [`proc-macro`]: proc_macro
 //! [`salvo`]: https://github.com/salvo-rs/salvo
+//! [`salvo_extra`]: https://crates.io/crates/salvo_extra
 #![doc = include_str!("../README.md")]
 
 use protect_endpoints_core::tower::middleware::GrantsLayer as CoreGrantsLayer;
 use salvo::http::ReqBody;
+
+/// Re-export of the `salvo_extra` crate with enabled tower-compatibility.
+pub use salvo_extra;
 
 pub mod authorities;
 

--- a/protect-salvo/tests/authorities_check/manual_check/enum_type.rs
+++ b/protect-salvo/tests/authorities_check/manual_check/enum_type.rs
@@ -1,10 +1,11 @@
 use crate::common::{self, Role};
 use protect_salvo::authorities::{AuthDetails, AuthoritiesCheck};
+use protect_salvo::salvo_extra::TowerLayerCompat;
 use protect_salvo::GrantsLayer;
 use salvo::http::header::AUTHORIZATION;
 use salvo::http::StatusCode;
 use salvo::test::TestClient;
-use salvo::{Response, Router, Service, TowerLayerCompat, Writer};
+use salvo::{Response, Router, Service, Writer};
 
 const ADMIN_RESPONSE: &str = "Hello Admin!";
 const OTHER_RESPONSE: &str = "Hello!";

--- a/protect-salvo/tests/authorities_check/manual_check/string_type.rs
+++ b/protect-salvo/tests/authorities_check/manual_check/string_type.rs
@@ -2,7 +2,8 @@ use crate::common::{self, ROLE_ADMIN, ROLE_MANAGER};
 use salvo::http::header::AUTHORIZATION;
 use salvo::http::StatusCode;
 use salvo::test::TestClient;
-use salvo::{Response, Router, Service, TowerLayerCompat, Writer};
+use salvo::{Response, Router, Service, Writer};
+use salvo_extra::TowerLayerCompat;
 
 use protect_endpoints_core::authorities::AuthoritiesCheck;
 use protect_salvo::authorities::AuthDetails;

--- a/protect-salvo/tests/proc_macro/different_fn_types.rs
+++ b/protect-salvo/tests/proc_macro/different_fn_types.rs
@@ -3,6 +3,7 @@ use protect_salvo::{protect, GrantsLayer};
 use salvo::http::header::{AUTHORIZATION, CONTENT_TYPE};
 use salvo::prelude::*;
 use salvo::test::TestClient;
+use salvo_extra::TowerLayerCompat;
 use serde::{Deserialize, Serialize};
 
 #[protect("ROLE_ADMIN")]

--- a/protect-salvo/tests/proc_macro/type_feature.rs
+++ b/protect-salvo/tests/proc_macro/type_feature.rs
@@ -5,6 +5,7 @@ use protect_salvo::GrantsLayer;
 use salvo::http::header::AUTHORIZATION;
 use salvo::prelude::*;
 use salvo::test::TestClient;
+use salvo_extra::TowerLayerCompat;
 
 // Using imported custom type (in `use` section)
 #[protect("ADMIN", ty = "Role")]


### PR DESCRIPTION
#### Description:
Updates salvo support to `0.75`
Also, bumps tower to `0.5` due to requirements
